### PR TITLE
read local mail by default

### DIFF
--- a/.byobu/.tmux.conf
+++ b/.byobu/.tmux.conf
@@ -1,5 +1,5 @@
 new -s tilde -n chat 'weechat-curses';
-neww -n mail 'alpine';
+neww -n mail 'mutt'; # ultimately revert back to alpine once alpine is configured to read local mail, not through IMAP
 neww -n shell;
 send-keys -t ":2" byobu-info Enter;
 


### PR DESCRIPTION
New users need to be able to read the starter email sent to the local mail box. Alpine seems to be a bit tricky to configure to read the local mail without installing add-ons [1]. We can open mutt by default but in the email maybe mention alpine as another choice.

[1] https://unix.stackexchange.com/questions/34954/how-do-i-set-up-alpine-to-read-local-unix-generated-mail