### PR TITLE
[irssi-config] Fix non-functioning default irc-network setup for irssi

### DIFF
--- a/.irssi/config
+++ b/.irssi/config
@@ -1,5 +1,5 @@
 servers = (
-  { address = "irc"; chatnet = "newnet"; port = "6667"; }
+  { address = "irc"; chatnet = "newnet"; port = "6667"; starttls = "no"; }
 );
 
 chatnets = {

--- a/.irssi/config
+++ b/.irssi/config
@@ -1,9 +1,9 @@
 servers = (
-  { address = "irc"; chatnet = "localhost"; port = "6667"; }
+  { address = "irc"; chatnet = "newnet"; port = "6667"; }
 );
 
 chatnets = {
-  tildenet = {
+  newnet = {
     type = "IRC";
     max_kicks = "4";
     max_msgs = "5";
@@ -13,8 +13,8 @@ chatnets = {
 };
 
 channels = (
-  { name = "#club"; chatnet = "tilde.chat"; autojoin = "No"; }
-  { name = "#meta"; chatnet = "tilde.chat"; autojoin = "No"; }
+  { name = "#club"; chatnet = "newnet"; autojoin = "No"; }
+  { name = "#meta"; chatnet = "newnet"; autojoin = "No"; }
 );
 
 aliases = {

--- a/.irssi/config
+++ b/.irssi/config
@@ -13,8 +13,8 @@ chatnets = {
 };
 
 channels = (
-  { name = "#club"; chatnet = "newnet"; autojoin = "No"; }
-  { name = "#meta"; chatnet = "newnet"; autojoin = "No"; }
+  { name = "#club"; chatnet = "newnet"; autojoin = "yes"; }
+  { name = "#meta"; chatnet = "newnet"; autojoin = "yes"; }
 );
 
 aliases = {

--- a/.irssi/startup
+++ b/.irssi/startup
@@ -1,3 +1,1 @@
 connect newnet
-join #club
-join #meta

--- a/.irssi/startup
+++ b/.irssi/startup
@@ -1,3 +1,3 @@
-connect irc
+connect newnet
 join #club
 join #meta


### PR DESCRIPTION
I recently joined tilde.club and I've noticed that the default irssi config isn't quite functioning. The biggest problem was that the chatnet-name in the irssi-config was all over the place: localhost, tildenet, tilde.chat, irc... I've chosen to choose "newnet" as the network-name. Also, while connecting, newnet tries to switch to tls using starttls, which fails, since irssi effectively connects to localhost and the certificate's CN isn't set up for that.